### PR TITLE
Fix: updating faicon's reactivity

### DIFF
--- a/src/FontAwesomeIcon.tsx
+++ b/src/FontAwesomeIcon.tsx
@@ -1,6 +1,6 @@
-import { JSX } from "solid-js";
+import { Accessor, createMemo, JSX } from "solid-js";
 import { FontAwesomeIconProps } from "./lib/types";
-import { parse, icon } from "@fortawesome/fontawesome-svg-core";
+import { parse, icon, Icon } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import "./styles.css";
 
@@ -10,7 +10,7 @@ export function FontAwesomeIcon(props: FontAwesomeIconProps): JSX.Element {
     typeof props.transform === "string" ? parse.transform(props.transform) : props.transform;
 
   // console.log(transform);
-  const faicon = icon(parse.icon(props.icon));
+  const faicon: Accessor<Icon> = createMemo<Icon>((): Icon => icon(parse.icon(props.icon)));
   // console.log(faicon);
 
   function classes() {
@@ -36,16 +36,16 @@ export function FontAwesomeIcon(props: FontAwesomeIconProps): JSX.Element {
   return (
     <svg
       aria-hidden="true"
-      data-prefix={faicon.prefix}
-      data-icon={faicon.iconName}
+      data-prefix={faicon().prefix}
+      data-icon={faicon().iconName}
       role="img"
       xmlns="http://www.w3.org/2000/svg"
-      viewBox={`0 0 ${faicon.icon[0]} ${faicon.icon[1]}`}
+      viewBox={`0 0 ${faicon().icon[0]} ${faicon().icon[1]}`}
       // class="svg-inline--fa fa-copy fa-fw fa-lg"
       class={classes()}
       style={styles()}
     >
-      <path fill="currentColor" d={faicon.icon[4] as string}></path>
+      <path fill="currentColor" d={faicon().icon[4] as string}></path>
     </svg>
   );
 }


### PR DESCRIPTION
## Problem
When re-assigning the `icon` prop for the `FontAwesomeIcon` component; we realized that the new icon's SVGs were not being pulled in appropriately.

## Solution
Force the `faicon` to be reactive via a memo so that anytime that the `props.icon` changes, we re-set the faicon so that it pull the new information for the new icon.

## Gif showing this in action 
- using `FontAwesomeIcon` within a button and changing the icon on click

![after_reactivity](https://github.com/gnomical/solid-fontawesome/assets/5696777/60bede53-b509-4fcb-8ed7-70cfd19c4cc6)

