### PR TITLE
feat: utilize the AbstractElement provided by font-awesome to build SVG element

### DIFF
--- a/src/FontAwesomeIcon.tsx
+++ b/src/FontAwesomeIcon.tsx
@@ -1,6 +1,6 @@
 import { Accessor, createMemo, For, JSX, Show } from "solid-js";
 import { FontAwesomeIconProps } from "./lib/types";
-import { parse, icon, Icon } from "@fortawesome/fontawesome-svg-core";
+import { parse, icon, AbstractElement } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import "./styles.css";
 
@@ -10,19 +10,22 @@ export function FontAwesomeIcon(props: FontAwesomeIconProps): JSX.Element {
     typeof props.transform === "string" ? parse.transform(props.transform) : props.transform;
 
   // console.log(transform);
-  const faicon: Accessor<Icon> = createMemo<Icon>(() => {
-    // console.log(parse.icon(props.icon));
-    // console.log(icon(parse.icon(props.icon)));
-    return icon(parse.icon(props.icon))
+
+  const abstract: Accessor<AbstractElement> = createMemo<AbstractElement>((): AbstractElement => {
+    const faicon = icon(parse.icon(props.icon));
+
+    // adding in check to verify that the provided props.icon was properly
+    // imported. If it was not, then we create an "empty" AbstractElement to
+    // return
+    if (!faicon) {
+      return { tag: "", attributes: {} };
+    }
+
+    return faicon.abstract[0];
   });
-  // console.log(faicon());
 
   function classes() {
-    let classList = [
-      "svg-inline--fa",
-      props.icon,
-      props.swapOpacity? "fa-swap-opacity": "",
-    ];
+    let classList = ["svg-inline--fa", props.icon, props.swapOpacity ? "fa-swap-opacity" : ""];
     classList.push(props.size ? `fa-${props.size}` : "");
     if (props.className) classList.push(props.className);
     if (props.inverse) classList.push("fa-inverse");
@@ -36,28 +39,32 @@ export function FontAwesomeIcon(props: FontAwesomeIconProps): JSX.Element {
     return styles;
   }
 
-  return (
-    <svg
-      aria-hidden="true"
-      data-prefix={faicon() ? faicon().prefix : ""}
-      data-icon={faicon() ? faicon().iconName : ""}
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox={faicon() ? `0 0 ${faicon().icon[0]} ${faicon().icon[1]}` : "0 0 512 512"}
-      class={classes()}
-      style={styles()}
-    >
-      <Show 
-        when={faicon()}
-        fallback={<path fill="red" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/>}
-      >
-        <For each={faicon().icon[4] as string[]} 
-          fallback={<path fill="currentColor" d={faicon().icon[4] as string}></path>}>
-          {(path) => (
-            <path fill="currentColor" d={path}></path>
-          )}
-        </For>
-      </Show>
+  const errSVG: JSX.Element = (): JSX.Element => (
+    <svg>
+      <path
+        fill="red"
+        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"
+      />
     </svg>
+  );
+
+  return (
+    <Show when={abstract().tag === "svg"} fallback={errSVG}>
+      <svg {...abstract().attributes} class={classes()} style={styles()}>
+        {/* renders the singular path if the first child is not set as a group */}
+        <Show when={(abstract().children || [])[0].tag === "path"}>
+          <path {...(abstract().children || [])[0].attributes}></path>
+        </Show>
+
+        {/* renders multiple paths for when the icon is duotone  */}
+        <Show when={(abstract().children || [])[0].tag === "g"}>
+          <g {...(abstract().children || [])[0].attributes}>
+            <For each={(abstract().children || [])[0].children}>
+              {path => <path {...path.attributes}></path>}
+            </For>
+          </g>
+        </Show>
+      </svg>
+    </Show>
   );
 }


### PR DESCRIPTION
## Problem Statement
As a user of the FontAwesomeIcon component, I wanted to utilize duotone icons and could not do so with this package.

## Proposed Solution
Instead of trying to port over the "converter" logic from [react-fontawesome](https://github.com/FortAwesome/react-fontawesome), I was able to keep the "build the SVG by hand" mentality, while also utilizing the AbstractElement provided to us by FontAwesome already.

In doing so, I was able to utilize SolidJS control Flow elements to allow for the elements to remain reactive when and if a new icon is passed in via the `icon` property.

## Notes
- I did replace most of the `svg`'s attributes with those provided to us by the AbstractElement as FontAwesome already did all of the calculations for us that we had been doing before.
- With the current set-up the `svg`'s `class` and `style` attributes are still being manually set as they had been before to keep with the previous logic before these changes.

## Gifs

### Before: no duotone, but allowed for switching of icons
![before_change](https://github.com/gnomical/solid-fontawesome/assets/5696777/442c0b10-7b61-401c-b96b-984514e60754)

### After: with duotone support and also allowing to switch from a duotone to non-duotone icon
![after_change](https://github.com/gnomical/solid-fontawesome/assets/5696777/b0d048bf-3ac3-4b41-a70b-7bf2c3bf2633)
